### PR TITLE
Added support for index.vue files as component

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -18,6 +18,10 @@ export default function stormModule (moduleOptions) {
       name = file.match(/components\/(.*?).vue$/)[1].replace(/\//g, '')
     } else {
       name = file.match(/(\w*)\.vue$/)[1]
+      // If file is an index.vue file, use folder name instead
+      if (name === 'index') {
+        name = file.replace('/index.vue', '').split('/').reverse()[0]
+      }
     }
     count++
     return { name, file }


### PR DESCRIPTION
Hey there, love the module you made. When I added it to my project I found a lot of components called 'index' because I use a file structure where I group related components together and use index.vue files as 'base' (sorta).

Example:
- /components/Header/index.vue (< Header />)
- /components/Header/Logo.vue (< Logo />)
- /components/Header/Menu.vue (< Menu />)
- etc.

I wrote a bit of code to use the folder name instead of 'index' for index.vue files.

Ps. this is my first fork/PR on a public repo so if could improve in some way please let me know :)