### PR TITLE
Get all nuxt components

### DIFF
--- a/dist/module.js
+++ b/dist/module.js
@@ -1,27 +1,17 @@
-import glob from 'glob';
 import { resolve } from 'path';
 import consola from 'consola';
 export default function stormModule(moduleOptions) {
     if (process.env.NODE_ENV === 'production') {
         return;
     }
-    const { nuxt } = this;
     let count = 0;
     const logger = consola.withScope('nuxt:storm');
-    const components = glob.sync(`${nuxt.options.srcDir}/components/**/*.vue`).map(file => {
-        let name;
-        if (moduleOptions.nested) {
-            name = file.match(/components\/(.*?).vue$/)[1].replace(/\//g, '');
-        }
-        else {
-            name = file.match(/(\w*)\.vue$/)[1];
-            // If file is an index.vue file, use folder name instead
-            if (name === 'index') {
-                name = file.replace('/index.vue', '').split('/').reverse()[0];
-            }
-        }
-        count++;
-        return { name, file };
+    let components;
+    this.nuxt.hook('components:extend', dirs => {
+        components = [...dirs].map(file => {
+            count++;
+            return { name: file.pascalName, file: file.filePath };
+        });
     });
     const getComponents = () => components;
     if (moduleOptions.nested) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-storm",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "private": false,
   "description": " PHPStorm support for NuxtJS components",
   "repository": "https://github.com/fumeapp/nuxt-storm",

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,26 +6,16 @@ export default function stormModule (moduleOptions) {
   if (process.env.NODE_ENV === 'production') {
     return
   }
-
-  const { nuxt } = this
-
   let count = 0
   const logger = consola.withScope('nuxt:storm')
 
-  const components = glob.sync(`${nuxt.options.srcDir}/components/**/*.vue`).map(file => {
-    let name
-    if (moduleOptions.nested) {
-      name = file.match(/components\/(.*?).vue$/)[1].replace(/\//g, '')
-    } else {
-      name = file.match(/(\w*)\.vue$/)[1]
-      // If file is an index.vue file, use folder name instead
-      if (name === 'index') {
-        name = file.replace('/index.vue', '').split('/').reverse()[0]
-      }
-    }
-    count++
-    return { name, file }
-  })
+  let components
+  this.nuxt.hook('components:extend', dirs => {
+    components = [...dirs].map(file => {
+      count++
+      return { name: file.pascalName, file: file.filePath}
+    })
+  });
 
   const getComponents = () => components
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,3 @@
-import glob from 'glob'
 import { resolve } from 'path'
 import consola from 'consola'
 


### PR DESCRIPTION
This module assumes you have all the components in only the components folder.
If you have components from a library, see https://github.com/nuxt/components#library-authors they are never here
Also this reinforces what nuxt thinks the names are, rather than make checks like 'name === 'index'

Nested option is deprecated