### PR TITLE
Add option to generate alias paths instead of absolute

### DIFF
--- a/dist/module.d.ts
+++ b/dist/module.d.ts
@@ -1,1 +1,6 @@
-export default function stormModule(moduleOptions: any): void;
+interface Options {
+    nested?: boolean;
+    alias?: string | boolean;
+}
+export default function stormModule(moduleOptions: Options): void;
+export {};

--- a/dist/module.js
+++ b/dist/module.js
@@ -10,7 +10,19 @@ export default function stormModule(moduleOptions) {
     this.nuxt.hook('components:extend', dirs => {
         components = [...dirs].map(file => {
             count++;
-            return { name: file.pascalName, file: file.filePath };
+            let filePath;
+            if (moduleOptions.alias) {
+                let alias;
+                if (typeof moduleOptions.alias !== 'string')
+                    alias = '@';
+                else
+                    alias = moduleOptions.alias;
+                filePath = `${alias}/${file.filePath.slice(file.filePath.indexOf('components'))}`;
+            }
+            else {
+                filePath = file.filePath;
+            }
+            return { name: file.pascalName, file: filePath };
         });
         if (moduleOptions.nested) {
             logger.info(`Nested components option detected`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-storm",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "description": " PHPStorm support for NuxtJS components",
   "repository": "https://github.com/fumeapp/nuxt-storm",

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,25 @@ The component name will contain its path:
 <MyFormTextArea />
 ```
 
+### Path alias
+
+Should your IDE fail to recognize vue component by its absolute path, you can replace it with path alias (default '@').
+
+Thus, the aforementioned component path will be listed as
+`@/components/My/Form/TextArea.vue`
+instead of 
+`C:/some/absolute/path/project/components/My/Form/TextArea.vue`.
+
+Add `alias: true` in your buildModule inclusion or set a custom alias as its value should you use one.
+
+```js
+{
+  buildModules: [
+    ['nuxt-storm', { alias: true }],
+  ]
+}
+```
+
 ### 🙏 Thanks
 
 This was made possible by with the help of [grunghi](https://github.com/grunghi) and [eggsy](https://github.com/eggsy/)

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,12 @@
 import { resolve } from 'path'
 import consola from 'consola'
 
-export default function stormModule (moduleOptions) {
+interface Options {
+  nested?: boolean
+  alias?: string | boolean
+}
+
+export default function stormModule (moduleOptions: Options) {
   if (process.env.NODE_ENV === 'production') {
     return
   }
@@ -12,7 +17,15 @@ export default function stormModule (moduleOptions) {
   this.nuxt.hook('components:extend', dirs => {
     components = [...dirs].map(file => {
       count++
-      return { name: file.pascalName, file: file.filePath}
+      let filePath
+      if (moduleOptions.alias) {
+        let alias
+        if (typeof moduleOptions.alias !== 'string') alias = '@'
+        else alias = moduleOptions.alias
+        filePath = `${alias}/${file.filePath.slice(file.filePath.indexOf('components'))}`
+      }
+      else { filePath = file.filePath }
+      return { name: file.pascalName, file: filePath}
     })
 
     if (moduleOptions.nested) {


### PR DESCRIPTION
WebStorm wouldn't resolve absolutes so I had to make do, figured might as well be an option here

Details in README