### PR TITLE
Adding support for lazyloaded components

### DIFF
--- a/templates/components.js
+++ b/templates/components.js
@@ -4,5 +4,7 @@ import Vue from 'vue'
 }).join('\n') %>
 
 <%= options.getComponents().map(({ name, file }) => {
-    return `Vue.component('${name}', ${name})`
+    let template = `Vue.component('${name}', ${name})`
+    template += `\nVue.component('Lazy${name}', ${name})`
+    return template
 }).join('\n') %>


### PR DESCRIPTION
Quick fix for lazy loadable components, this would fix #2 

It might make sense to make it configurable since it clutters user components with the name "lazy" in front, but the components are "there" so not sure.