### PR TITLE
chore: add type="module" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dist",
     "templates"
   ],
+  "type": "module",
   "main": "./dist/module.js",
   "scripts": {
     "build": "tsc"


### PR DESCRIPTION
This is needed so bundlers no what to do and expect (for example Vite)

This fixes #11 